### PR TITLE
New selection modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,6 @@ To begin using it just follow this simple steps:
 ## Known Issues
 
 ## TODOs
-- [ ] change animationClasses syntax to make it more natural
 - [ ] add customizable 'active' attribute
 - [ ] add class mode in addition to attribute mode
 - [ ] add more sample animations in it's own dedicated folder

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ To begin using it just follow this simple steps:
 ## Known Issues
 
 ## TODOs
-- [ ] add numeric index selection without the need for attrForSelected
+- [ ] add selectNext() and selectPrevious() methods
 - [ ] add customizable 'active' attribute
 - [ ] add class mode in addition to attribute mode
 - [ ] add more sample animations in it's own dedicated folder

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ To begin using it just follow this simple steps:
 ## Known Issues
 
 ## TODOs
-- [ ] add selectNext() and selectPrevious() methods
+- [ ] change animationClasses syntax to make it more natural
 - [ ] add customizable 'active' attribute
 - [ ] add class mode in addition to attribute mode
 - [ ] add more sample animations in it's own dedicated folder

--- a/demo/demo-element.js
+++ b/demo/demo-element.js
@@ -1,4 +1,5 @@
 import { LitElement, html } from '@polymer/lit-element';
+import './noattr-demo.js';
 import '../helium-animated-pages.js';
 import { FadeIn } from '../in-animations.js';
 import { FadeOut } from '../out-animations.js';
@@ -27,6 +28,7 @@ class DemoElement extends LitElement {
         <h2>Select a page</h2>
         <select onchange="${(e) => this._selectMainPage(e)}">
           <option value="">Select page...</option>
+          <option value="noattr">No attrForSelected Demo</option>
           <option value="page1">Page 1</option>
           <option value="page2">Page 2</option>
           <option value="page3">Page 3</option>
@@ -34,6 +36,7 @@ class DemoElement extends LitElement {
       </section>
       <helium-animated-pages id="main" attrForSelected="name"
         animationClasses="${_mainAnimationClasses}">
+        <noattr-demo name="noattr"></noattr-demo>
         <section name="page1">Page 1</section>
         <section name="page2">Page 2</section>
         <section name="page3">Page 3</section>

--- a/demo/demo-element.js
+++ b/demo/demo-element.js
@@ -1,5 +1,6 @@
 import { LitElement, html } from '@polymer/lit-element';
 import './noattr-demo.js';
+import './prevnext-demo.js';
 import '../helium-animated-pages.js';
 import { FadeIn } from '../in-animations.js';
 import { FadeOut } from '../out-animations.js';
@@ -29,6 +30,7 @@ class DemoElement extends LitElement {
         <select onchange="${(e) => this._selectMainPage(e)}">
           <option value="">Select page...</option>
           <option value="noattr">No attrForSelected Demo</option>
+          <option value="prevnext">selectPrevious()/selectNext() Demo</option>
           <option value="page1">Page 1</option>
           <option value="page2">Page 2</option>
           <option value="page3">Page 3</option>
@@ -37,6 +39,7 @@ class DemoElement extends LitElement {
       <helium-animated-pages id="main" attrForSelected="name"
         animationClasses="${_mainAnimationClasses}">
         <noattr-demo name="noattr"></noattr-demo>
+        <prevnext-demo name="prevnext"></prevnext-demo>
         <section name="page1">Page 1</section>
         <section name="page2">Page 2</section>
         <section name="page3">Page 3</section>

--- a/demo/noattr-demo.js
+++ b/demo/noattr-demo.js
@@ -1,0 +1,74 @@
+import { html } from '@polymer/lit-element';
+import { PageViewElement } from './page-view-element.js';
+import '../helium-animated-pages.js';
+import { RotateUnfoldLeft, RotateUnfoldRight } from '../in-animations.js';
+import { MoveToLeft, MoveToRight } from '../out-animations.js';
+
+class NoattrDemo extends PageViewElement {
+  _render({_noattrAnimationClasses}) {
+    return html`
+    ${RotateUnfoldLeft}
+    ${RotateUnfoldRight}
+    ${MoveToLeft}
+    ${MoveToRight}
+    <style>
+      :host {
+        background: lightpink;
+      }
+      section.container {
+        width: 70vw;
+        height: 50vh;
+        position: relative;
+      }
+      section.slide1 {
+        background-color: black;
+        color: white;
+      }
+      section.slide2 {
+        background-color: white;
+      }
+    </style>
+    <section>
+      <h3>This page has just 2 slides and it doesn't use an attribute for the selection</h3>
+      <select onchange="${(e) => this._selectPage(e)}">
+        <option value="">Select slide...</option>
+        <option value="0">Slide 1</option>
+        <option value="1">Slide 2</option>
+      </select>
+    </section>
+    <section class="container">
+      <helium-animated-pages id="noattr"
+        animationClasses="${_noattrAnimationClasses}">
+        <section class="slide1">Slide 1</section>
+        <section class="slide2">Slide 2</section>
+      </helium-animated-pages>
+    </section>
+    `;
+  }
+  static get properties() {
+    return {
+      _noattrAnimationClasses: Object,
+    };
+  }
+  constructor() {
+    super();
+    this._noattrAnimationClasses = {
+      '1_': {
+        in: 'page-rotateUnfoldRight',
+        out: 'page-moveToLeft'
+      },
+      '0_': {
+        in: 'page-rotateUnfoldLeft',
+        out: 'page-moveToRight'
+      }
+    };
+  }
+  _selectPage(e) {
+    if(e.target.value){
+      const index = parseInt(e.target.value);
+      this.shadowRoot.querySelector('#noattr').select(index);
+    }
+  }
+}
+
+window.customElements.define('noattr-demo', NoattrDemo);

--- a/demo/noattr-demo.js
+++ b/demo/noattr-demo.js
@@ -53,11 +53,11 @@ class NoattrDemo extends PageViewElement {
   constructor() {
     super();
     this._noattrAnimationClasses = {
-      '1_': {
+      '*_1': {
         in: 'page-rotateUnfoldRight',
         out: 'page-moveToLeft'
       },
-      '0_': {
+      '*_0': {
         in: 'page-rotateUnfoldLeft',
         out: 'page-moveToRight'
       }

--- a/demo/page-view-element.js
+++ b/demo/page-view-element.js
@@ -1,0 +1,24 @@
+/**
+@license
+Copyright (c) 2018 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+*/
+
+import { LitElement } from '@polymer/lit-element';
+
+export class PageViewElement extends LitElement {
+  // Only render this page if it's actually visible.
+  _shouldRender(props, changedProps, old) {
+    return props.active;
+  }
+
+  static get properties() {
+    return {
+      active: Boolean
+    }
+  }
+}

--- a/demo/prevnext-demo.js
+++ b/demo/prevnext-demo.js
@@ -1,0 +1,133 @@
+import { html } from '@polymer/lit-element';
+import { PageViewElement } from './page-view-element.js';
+import '../helium-animated-pages.js';
+import { FadeIn, RotateUnfoldLeft, RotateUnfoldRight} from '../in-animations.js';
+import { FadeOut, MoveToLeft, MoveToRight } from '../out-animations.js';
+
+class PrevnextDemo extends PageViewElement {
+  _render(props) {
+    return html`
+    ${FadeIn}
+    ${FadeOut}
+    ${RotateUnfoldLeft}
+    ${RotateUnfoldRight}
+    ${MoveToLeft}
+    ${MoveToRight}
+    <style>
+      :host {
+        background: lightyellow;
+      }
+      section.container {
+        width: 50vw;
+        height: 20vh;
+        position: relative;
+      }
+      div:nth-of-type(odd) {
+        background-color: black;
+        color: white;
+      }
+      div:nth-of-type(even) {
+        background-color: white;
+      }
+    </style>
+    <section>
+      <h3>This page has 2 slideshows which only use selectNext() and selectPrevious() to iterate</h3>
+    </section>
+    <section>
+      <h4>First slideshow, no attrForSelected</h4>
+      <input type="button" value="previous" onclick="${(e) => this._selectNoattr(e)}">
+      <input type="button" value="next" onclick="${(e) => this._selectNoattr(e)}">
+    </section>
+    <section class="container">
+      <helium-animated-pages id="noattr"
+        animationClasses="${props._noattrAnimationClasses}">
+        <div>Slide 1</div>
+        <div>Slide 2</div>
+        <div>Slide 3</div>
+      </helium-animated-pages>
+    </section>
+    <section>
+      <h4>Second slideshow, with attrForSelected (the way of defining the animationClasses changes)</h4>
+      <input type="button" value="previous" onclick="${(e) => this._selectAttr(e)}">
+      <input type="button" value="next" onclick="${(e) => this._selectAttr(e)}">
+    </section>
+    <section class="container">
+      <helium-animated-pages id="attr" attrForSelected="name"
+        animationClasses="${props._attrAnimationClasses}">
+        <div name="slide1">Slide 1</div>
+        <div name="slide2">Slide 2</div>
+        <div name="slide3">Slide 3</div>
+      </helium-animated-pages>
+    </section>
+    `;
+  }
+  static get properties() {
+    return {
+      _attrAnimationClasses: Object,
+      _noattrAnimationClasses: Object,
+    };
+  }
+  _selectNoattr(e) {
+    const pages = this.shadowRoot.querySelector('#noattr');
+    if(e.target.value === 'next') {
+      pages.selectNext();
+    }
+    pages.selectPrevious();
+  }
+  _selectAttr(e) {
+    const pages = this.shadowRoot.querySelector('#attr');
+    if(e.target.value === 'next') {
+      pages.selectNext();
+    }
+    pages.selectPrevious();
+  }
+  constructor() {
+    super();
+    this._noattrAnimationClasses = {
+      '1_0': {
+        in: 'page-rotateUnfoldRight',
+        out: 'page-moveToLeft'
+      },
+      '1_2': {
+        in: 'page-rotateUnfoldLeft',
+        out: 'page-moveToRight'
+      },
+      '0_': {
+        in: 'page-rotateUnfoldLeft',
+        out: 'page-moveToRight'
+      },
+      '2_': {
+        in: 'page-rotateUnfoldRight',
+        out: 'page-moveToLeft'
+      },
+      default: {
+        in: 'page-fadeIn',
+        out: 'page-fadeOut'
+      }
+    };
+    this._attrAnimationClasses = {
+      'slide2_slide1': {
+        in: 'page-rotateUnfoldRight',
+        out: 'page-moveToLeft'
+      },
+      'slide2_slide3': {
+        in: 'page-rotateUnfoldLeft',
+        out: 'page-moveToRight'
+      },
+      'slide1_': {
+        in: 'page-rotateUnfoldLeft',
+        out: 'page-moveToRight'
+      },
+      'slide3_': {
+        in: 'page-rotateUnfoldRight',
+        out: 'page-moveToLeft'
+      },
+      default: {
+        in: 'page-fadeIn',
+        out: 'page-fadeOut'
+      }
+    };
+  }
+}
+
+window.customElements.define('prevnext-demo', PrevnextDemo);

--- a/demo/prevnext-demo.js
+++ b/demo/prevnext-demo.js
@@ -84,21 +84,29 @@ class PrevnextDemo extends PageViewElement {
   constructor() {
     super();
     this._noattrAnimationClasses = {
-      '1_0': {
+      '0_1': {
         in: 'page-rotateUnfoldRight',
         out: 'page-moveToLeft'
       },
-      '1_2': {
+      '2_1': {
         in: 'page-rotateUnfoldLeft',
         out: 'page-moveToRight'
       },
-      '0_': {
+      '*_0': {
         in: 'page-rotateUnfoldLeft',
         out: 'page-moveToRight'
       },
-      '2_': {
+      '*_2': {
         in: 'page-rotateUnfoldRight',
         out: 'page-moveToLeft'
+      },
+      '_0': {
+        in: 'page-fadeIn',
+        out: 'page-fadeOut'
+      },
+      '_2': {
+        in: 'page-fadeIn',
+        out: 'page-fadeOut'
       },
       default: {
         in: 'page-fadeIn',
@@ -106,21 +114,29 @@ class PrevnextDemo extends PageViewElement {
       }
     };
     this._attrAnimationClasses = {
-      'slide2_slide1': {
+      'slide1_slide2': {
         in: 'page-rotateUnfoldRight',
         out: 'page-moveToLeft'
       },
-      'slide2_slide3': {
+      'slide3_slide2': {
         in: 'page-rotateUnfoldLeft',
         out: 'page-moveToRight'
       },
-      'slide1_': {
+      '*_slide1': {
         in: 'page-rotateUnfoldLeft',
         out: 'page-moveToRight'
       },
-      'slide3_': {
+      '*_slide3': {
         in: 'page-rotateUnfoldRight',
         out: 'page-moveToLeft'
+      },
+      '_slide1': {
+        in: 'page-fadeIn',
+        out: 'page-fadeOut'
+      },
+      '_slide3': {
+        in: 'page-fadeIn',
+        out: 'page-fadeOut'
       },
       default: {
         in: 'page-fadeIn',

--- a/helium-animated-pages.js
+++ b/helium-animated-pages.js
@@ -76,12 +76,10 @@ class HeliumAnimatedPages extends LitElement {
     if (!this.animationClasses) {
       throw new Error('animationClasses must be defined');
     }
-
     // Do nothing if the animation is running
     if (this._animating) return;
 
     const stringMode = this._isStringMode(next);
-
     if(stringMode && !this.attrForSelected) {
       throw new Error('attrForSelected must be defined if next is a string');
     }
@@ -105,6 +103,83 @@ class HeliumAnimatedPages extends LitElement {
       this._outPage.getAttribute(this.attrForSelected) :
       this._outPage ? Array.from(this.children).indexOf(this._outPage) :
       '';
+    this._currentClasses = this._animationClasses(next, prev);
+    this._beginAnimation();
+  }
+
+  selectNext() {
+    if (!this.animationClasses) {
+      throw new Error('animationClasses must be defined');
+    }
+    // Do nothing if the animation is running
+    if (this._animating) return;
+    const children = Array.from(this.children);
+    this._outPage = this.querySelector(`[active]`);
+    let prevIndex;
+    let nextIndex = 0;
+    if (this._outPage) {
+      prevIndex = children.indexOf(this._outPage);
+      nextIndex = prevIndex + 1;
+      if(nextIndex >= children.length) {
+        nextIndex = 0;
+        this._inPage = children[0];
+      } else{
+        this._inPage = children[nextIndex];
+      }
+    } else if (children){
+      prevIndex = '';
+      this._inPage = children[0];
+    } else {
+      throw new Error('This component has no children to animate');
+    }
+    // Do nothing if the same page is being selected
+    if(this._inPage === this._outPage) return;
+
+    let next = this.attrForSelected ?
+      this._inPage.getAttribute(this.attrForSelected) :
+      nextIndex;
+    let prev = this._outPage && this.attrForSelected ?
+      this._outPage.getAttribute(this.attrForSelected) :
+      prevIndex;
+    this._currentClasses = this._animationClasses(next, prev);
+    this._beginAnimation();
+  }
+
+  selectPrevious() {
+    if (!this.animationClasses) {
+      throw new Error('animationClasses must be defined');
+    }
+    // Do nothing if the animation is running
+    if (this._animating) return;
+    const children = Array.from(this.children);
+    this._outPage = this.querySelector(`[active]`);
+    let prevIndex;
+    const last = children.length - 1;
+    let nextIndex = last;
+    if (this._outPage) {
+      prevIndex = children.indexOf(this._outPage);
+      nextIndex = prevIndex - 1;
+      if(nextIndex < 0) {
+        nextIndex = last;
+        this._inPage = children[last];
+      } else{
+        this._inPage = children[nextIndex];
+      }
+    } else if (children){
+      prevIndex = '';
+      this._inPage = children[last];
+    } else {
+      throw new Error('This component has no children to animate');
+    }
+    // Do nothing if the same page is being selected
+    if(this._inPage === this._outPage) return;
+
+    let next = this.attrForSelected ?
+      this._inPage.getAttribute(this.attrForSelected) :
+      nextIndex;
+    let prev = this._outPage && this.attrForSelected ?
+      this._outPage.getAttribute(this.attrForSelected) :
+      prevIndex;
     this._currentClasses = this._animationClasses(next, prev);
     this._beginAnimation();
   }

--- a/helium-animated-pages.js
+++ b/helium-animated-pages.js
@@ -198,9 +198,9 @@ class HeliumAnimatedPages extends LitElement {
   }
 
   _animationClasses(next, prev) {
-    const fullId = `${next}_${prev}`;
-    const toId = `_${prev}`;
-    const fromId = `${next}_`;
+    const fullId = `${prev}_${next}`;
+    const toId = `*_${next}`;
+    const fromId = `${prev}_*`;
     if (fullId in this.animationClasses) {
       return this.animationClasses[fullId];
     } else if (toId in this.animationClasses) {


### PR DESCRIPTION
Adds:
- select(int): so that attrForSelected becomes optional
- selectPrevious() and selectNext(): for slideshow-like behavior

Breaking Changes:
- animationClasses syntax was updated:
  - It's more natural flowing (`from_to` instead of `to_from`)
  - `_to` and `from_` now apply to cases when no page was previously selected, for wildcard use `*_to` or `from_*`